### PR TITLE
Windows path in EditorInputUtil

### DIFF
--- a/src/org/eclipse/imp/editor/EditorInputUtils.java
+++ b/src/org/eclipse/imp/editor/EditorInputUtils.java
@@ -82,6 +82,7 @@ public class EditorInputUtils {
             IWorkspaceRoot wsRoot= ResourcesPlugin.getWorkspace().getRoot();
             URI uri= uriEditorInput.getURI();
             String path= uri.getPath();
+            // Bug 526: uri.getHost() can be null for a local file URL
             String workspaceRoot = fixWindowsPath(wsRoot.getLocation().toString());
             if (uri.getScheme().equals("file") && (uri.getHost() == null || uri.getHost().equals("localhost")) && path.startsWith(workspaceRoot)) {
                 file= wsRoot.getFile(new Path(path));


### PR DESCRIPTION
While debugging path issues in Rascal MPL, I found two issues here:
- wsRoot.getLocation().toOSString() will on windows look like c:\folder\file.ext, while path is /c:/folder/file.ext, so using toString instead of toOSString will make a better match here
- on windows there is a leading slash missing, as required by the java URI implementation (other systems are more tolerant for this)
