### PR TITLE
Add dispose method to IParseController

### DIFF
--- a/src/org/eclipse/imp/editor/ParserScheduler.java
+++ b/src/org/eclipse/imp/editor/ParserScheduler.java
@@ -176,4 +176,8 @@ public class ParserScheduler extends Job {
             RuntimePlugin.getInstance().writeInfoMsg("No AST; bypassing listener notification.");
         }
     }
+
+	public void dispose() {
+		fParseController.dispose();
+	}
 }

--- a/src/org/eclipse/imp/editor/UniversalEditor.java
+++ b/src/org/eclipse/imp/editor/UniversalEditor.java
@@ -1363,8 +1363,9 @@ public class UniversalEditor extends TextEditor implements IASTFindReplaceTarget
 
         if (fParserScheduler != null) {
         	fParserScheduler.cancel(); // avoid unnecessary work after the editor is asked to close down
+        	fParserScheduler.dispose();
+        	fParserScheduler= null;
         }
-        fParserScheduler= null;
         
         ISourceViewer ssv = getSourceViewer();
         if (ssv != null && ssv instanceof StructuredSourceViewer) {

--- a/src/org/eclipse/imp/parser/IParseController.java
+++ b/src/org/eclipse/imp/parser/IParseController.java
@@ -117,4 +117,9 @@ public interface IParseController extends ILanguageService {
      * language
      */
     IAnnotationTypeInfo getAnnotationTypeInfo();
+
+    /**
+     * Allows to free resources if the associated editor window gets closed
+     */
+    void dispose();
 }

--- a/src/org/eclipse/imp/parser/ParseControllerBase.java
+++ b/src/org/eclipse/imp/parser/ParseControllerBase.java
@@ -94,4 +94,8 @@ public abstract class ParseControllerBase implements IParseController {
 	public IDocument getDocument() {
 	    return fDocument;
 	}
+
+	public void dispose() {
+		// Does nothing by default.
+	}
 }


### PR DESCRIPTION
This allows implementations of `IParseController` to free resources if associated editor window gets closed. A default implementation for this method is added to `ParseControllerBase` to avoid a breaking change.

Let me know what you think.

Best,
Sven
